### PR TITLE
Introduce workflow to automatically generate and publish doxygen docs

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,12 +33,12 @@ jobs:
       
       - name: Generate Documentation
         run: |
-          sudo apt-get install -y doxygen
+          doxygen Doxyfile
         
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'docs'
+          path: 'docs/html'
           
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Introduces the general structure of building and publishing the doxygen documentation to GitHub pages. 

The action is automatically executed as soon as something is merged into `main` and will use `doxygen` to generate the documentation. After this succeeded the `GitHub Pages` action is used to publish the `docs` folder. 